### PR TITLE
fix: add missing runtime dependencies for torch-runtime install

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,16 @@ conda create -n moss-tts python=3.12 -y
 conda activate moss-tts
 ```
 
-Install all required dependencies:
+Install the FFmpeg system dependency (required by `torchcodec` for audio I/O):
+
+```bash
+# Debian/Ubuntu
+sudo apt-get install -y ffmpeg
+# macOS
+brew install ffmpeg
+```
+
+Install all required Python dependencies:
 
 ```bash
 git clone https://github.com/OpenMOSS/MOSS-TTS.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ torch-runtime = [
     "torchaudio==2.9.1+cu128",
     "torchcodec===0.8.1",
     "transformers==5.0.0",
+    "accelerate>=1.10.1",
 ]
 
 # llama.cpp backend — torch-free core


### PR DESCRIPTION
Add accelerate to torch-runtime extras (required for device_map="auto" inference, not just finetuning) and document the FFmpeg system dependency in the README (required by torchcodec for audio I/O).