### PR TITLE
fix: use correct version operator for torchcodec dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ finetune-deepspeed = [
 torch-runtime = [
     "torch==2.9.1+cu128",
     "torchaudio==2.9.1+cu128",
-    "torchcodec===0.8.1",
+    "torchcodec==0.8.1",
     "transformers==5.0.0",
     "accelerate>=1.10.1",
 ]


### PR DESCRIPTION
fix: use correct version operator for torchcodec dependency