### PR TITLE
fix: update broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,4 +750,4 @@ Models in MOSS-TTS Family are licensed under the Apache License 2.0.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=OpenMOSS/MOSS-TTS&type=date&legend=top-left)](https://www.star-history.com/#OpenMOSS/MOSS-TTS&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=OpenMOSS/MOSS-TTS&type=date&legend=top-left)](https://star-history.dera.page/#OpenMOSS/MOSS-TTS&type=date&legend=top-left)

--- a/README_zh.md
+++ b/README_zh.md
@@ -760,4 +760,4 @@ MOSS-TTS 家族中的模型使用 Apache License 2.0 许可证。
 
 ## 星标历史数据
 
-[![Star History Chart](https://api.star-history.com/svg?repos=OpenMOSS/MOSS-TTS&type=date&legend=top-left)](https://www.star-history.com/#OpenMOSS/MOSS-TTS&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=OpenMOSS/MOSS-TTS&type=date&legend=top-left)](https://star-history.dera.page/#OpenMOSS/MOSS-TTS&type=date&legend=top-left)


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This change points the chart to the new domain so it works again.

The owner/repo in the chart matches the current repository origin, so no additional updates are needed.