### PR TITLE
readme: add MOSS-TTS ComfyUI node pack to Community Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,7 @@ We compare **MOSS Audio Tokenizer** with open-source audio tokenizers on the Lib
 
 ### 🌟 Community Projects
 The MOSS-TTS community has been growing rapidly, and we’re delighted to showcase some outstanding projects and features built by community members:
+- **[MOSS-TTS ComfyUI](https://github.com/CloudRipple/MOSS-TTS-ComfyUI)** — A ComfyUI node pack for the MOSS-TTS family (Registry id `moss-tts`), maintained by members of OpenMOSS team. Supports zero-shot voice cloning, continuation, and duration control.
 - **[ComfyUI-MOSS-TTS](https://github.com/richservo/comfyui-moss-tts)** A MOSS-TTS extension for ComfyUI.
 - **[MOSS-TTS-OpenAI](https://github.com/dasilva333/moss-tts-openai)** An OpenAI-compatible TTS API for MOSS-TTS.
 - **[AnyPod](https://github.com/rulerman/AnyPod)** A podcast generation tool using MOSS-TTS/MOSS-TTSD as the backend.

--- a/README_zh.md
+++ b/README_zh.md
@@ -721,6 +721,7 @@ $T_{\text{LLM-first-sentence}} + T_{\text{MOSS-TTS-Realtime-TTFB}} = 197ms + 180
 
 ### 🌟 社区项目
 MOSS-TTS 社区正在快速发展，我们也很高兴展示一些由社区成员构建的优秀项目与功能：
+- **[MOSS-TTS ComfyUI](https://github.com/CloudRipple/MOSS-TTS-ComfyUI)**：面向 ComfyUI 的 MOSS-TTS 系列节点包（Registry ID `moss-tts`），由 OpenMOSS 团队成员维护。支持零样本克隆、续写与时长控制。
 - **[ComfyUI-MOSS-TTS](https://github.com/richservo/comfyui-moss-tts)**：面向 ComfyUI 的 MOSS-TTS 扩展。
 - **[MOSS-TTS-OpenAI](https://github.com/dasilva333/moss-tts-openai)**：兼容 OpenAI 接口的 MOSS-TTS API。
 - **[AnyPod](https://github.com/rulerman/AnyPod)**：以 MOSS-TTS/MOSS-TTSD 作为后端的播客生成工具。


### PR DESCRIPTION
Adds the MOSS-TTS ComfyUI custom-node pack ([CloudRipple/MOSS-TTS-ComfyUI](https://github.com/CloudRipple/MOSS-TTS-ComfyUI), ComfyUI Registry id `moss-tts`) to the Community Projects sections of README.md and README_zh.md, listed first since it is maintained by members of the OpenMOSS team.

The pack provides ComfyUI nodes for the MOSS-TTS family (TTS, voice cloning, continuation, duration control), vendors the models' remote code with clearly marked compatibility patches (no `trust_remote_code`), works on transformers 4.x/5.x, and integrates with ComfyUI's ModelPatcher / AIMDO memory management.

It also addresses the recurring "existing ComfyUI extensions are broken on recent ComfyUI" requests (e.g. MOSS-TTS-v1.5 discussions#5), since this pack feature-detects ComfyUI internals instead of pinning them.